### PR TITLE
fix: resolve ClearML AttributeError by removing problematic requests monkey-patch

### DIFF
--- a/backend/model_manager.py
+++ b/backend/model_manager.py
@@ -30,17 +30,7 @@ except AttributeError:
     pass
 
 # Configure global session defaults to prevent excessive retries
-try:
-    # Set more aggressive defaults for requests/urllib3
-    requests.sessions.Session.request = lambda self, *args, **kwargs: (
-        super(requests.sessions.Session, self).request(
-            *args, 
-            timeout=kwargs.get('timeout', 10),
-            **kwargs
-        )
-    )
-except:
-    pass
+# Note: Removed problematic monkey-patch that caused AttributeError with super().request
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Fixes issue #44 where ClearML initialization failed with AttributeError

## Changes
- Remove problematic monkey-patch of requests.sessions.Session.request that used super() incorrectly
- Allow ClearML to use requests normally without inheritance conflicts
- Prevent training errors during ClearML initialization

## Root Cause
The error was caused by lines 35-43 that monkey-patched requests.sessions.Session.request with a lambda function using super() in the wrong context. When ClearML tried to make HTTP requests, it hit this problematic code and failed with AttributeError.

## Test Plan
- Run training and verify ClearML initializes without AttributeError
- Confirm training data is logged to ClearML dashboard
- Ensure no regression in other functionality

Generated with [Claude Code](https://claude.ai/code)